### PR TITLE
Updates backend to use gitlab API v4

### DIFF
--- a/lib/gitlab.js
+++ b/lib/gitlab.js
@@ -19,7 +19,7 @@ module.exports = function (options) {
         request({
           method: 'GET',
           json: true,
-          url: `${url}/v3/projects/${id}/repository/files/package.json?ref=master`,
+          url: `${url}/v4/projects/${id}/repository/files/package.json?ref=master`,
           headers
         }, (err, results) => {
           if (err) return reject(err)


### PR DESCRIPTION
Gitlab API v3 is no longer supported

This was causing the app to give an error:
> ☁️ The package <packagename> for <owner> could not be found.
even though that package existed.

Fixed by bumping  the request to use v4
